### PR TITLE
Add DI support to fake handlers via IServiceProvider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -401,3 +401,4 @@ FodyWeavers.xsd
 *.idea
 
 .qodo
+.qwen

--- a/README.md
+++ b/README.md
@@ -231,11 +231,6 @@ Sometimes you can have a lot of `FromRequest` and `FromResponse` fakes configure
 
 Your fake response class:
 ```csharp
-using System;
-using System.Net;
-using System.Net.Http;
-using System.Threading.Tasks;
-
 public class MyFakeResponseClass : IFakeResponseFromRequestAsync
 {
     public Func<IServiceProvider, HttpRequestMessage, Task<HttpResponseMessage?>> GetFakeResponseFromRequestAsync()

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Fresp - Fake Responses
 
-Fresp (shorthand for `fake response`) is a .NET package based on `DelegatingHandler` that provides a way to mock API responses through your `HttpClient` during application execution. It allows you to configure both synchronous and asynchronous fake responses based on the incoming `HttpRequestMessage` or `HttpResponseMessage`.
+Fresp (shorthand for `fake response`) is a .NET package based on `DelegatingHandler` that provides a way to mock API responses through your `HttpClient` during application execution. It allows you to configure both synchronous and asynchronous fake responses based on the incoming `HttpRequestMessage` or `HttpResponseMessage`, with full access to `IServiceProvider` for dependency injection.
 
 ## Problem
 
@@ -61,6 +61,9 @@ There are two ways to return fake responses, `FromRequest` and `FromResponse`:
 
 - **FromResponse**: will return a fake response <b>after</b> the request was sent to the target API, if the response predicate is matched.
 
+> [!TIP]
+> All fake response handlers receive `IServiceProvider` as their first parameter, allowing you to resolve any registered service (databases, caches, other HttpClients, etc.).
+
 #### Fake responses from request
 
 To add a fake response from a <b>request</b>, use the method `AddFakeResponseFromRequest` for synchronous request calls or `AddFakeResponseFromRequestAsync` for asynchronous request calls:
@@ -71,7 +74,7 @@ services.AddHttpClient("MyClient")
         .AddFakeHandler(options =>
         {
             options.Enabled = true;
-            options.AddFakeResponseFromRequest(request =>
+            options.AddFakeResponseFromRequest((serviceProvider, request) =>
             {
               if (request.RequestUri?.AbsolutePath == "/endpoint")
               {
@@ -90,7 +93,7 @@ services.AddHttpClient("MyClient")
         .AddFakeHandler(options =>
         {
             options.Enabled = true;
-            options.AddFakeResponseFromRequestAsync(async request =>
+            options.AddFakeResponseFromRequestAsync(async (serviceProvider, request) =>
             {
               var body = await request.Content.ReadAsStringAsync();
               if (body.Contains("something"))
@@ -116,7 +119,7 @@ services.AddHttpClient("MyClient")
         .AddFakeHandler(options =>
         {
             options.Enabled = true;
-            options.AddFakeResponseFromResponse(response =>
+            options.AddFakeResponseFromResponse((serviceProvider, response) =>
             {
               if (response.StatusCode == HttpStatusCode.ServiceUnavailable)
               {
@@ -135,7 +138,7 @@ services.AddHttpClient("MyClient")
         .AddFakeHandler(options =>
         {
             options.Enabled = true;
-            options.AddFakeResponseFromResponse(async response =>
+            options.AddFakeResponseFromResponseAsync(async (serviceProvider, response) =>
             {
               var body = await response.Content.ReadAsStringAsync();
               if (body.Contains("something"))
@@ -165,17 +168,79 @@ services.AddHttpClient("FakeHttpClient")
         .ConfigureHttpClient(c => c.BaseAddress = new Uri("http://this-api-does-not-exist.com"));
 ```
 
+#### Accessing Dependencies (DI)
+
+All fake response handlers have access to the `IServiceProvider`, allowing you to resolve any registered service (databases, caches, other HttpClients, configuration, etc.):
+
+```csharp
+services.AddHttpClient("MyClient")
+        .AddFakeHandler(options =>
+        {
+            options.Enabled = true;
+            options.AddFakeResponseFromRequest((serviceProvider, request) =>
+            {
+                var db = serviceProvider.GetRequiredService<IMyDbContext>();
+                var data = db.MyEntities.FirstOrDefault();
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(data?.ToJson() ?? "no data")
+                };
+            });
+        });
+```
+
+**Async with DI:**
+```csharp
+options.AddFakeResponseFromRequestAsync(async (serviceProvider, request) =>
+{
+    var cache = serviceProvider.GetRequiredService<IDistributedCache>();
+    var cached = await cache.GetStringAsync("my-key");
+    if (cached != null)
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(cached)
+        };
+    }
+    return null;
+});
+```
+
+**From Response with DI:**
+```csharp
+options.AddFakeResponseFromResponse((serviceProvider, response) =>
+{
+    if (response.StatusCode == HttpStatusCode.InternalServerError)
+    {
+        var logger = serviceProvider.GetRequiredService<ILogger<MyService>>();
+        logger.LogWarning("API returned 500, returning fallback response");
+
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"fallback\": true}")
+        };
+    }
+    return null;
+});
+```
+
 #### Multiple Fake Responses
 
 Sometimes you can have a lot of `FromRequest` and `FromResponse` fakes configured in options. To make it cleaner, you can use classes that implement some of the interfaces: `IFakeResponseFromRequest`, `IFakeResponseFromRequestAsync`, `IFakeResponseFromResponse`, and `IFakeResponseFromResponseAsync`. E.g.:
 
 Your fake response class:
 ```csharp
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
 public class MyFakeResponseClass : IFakeResponseFromRequestAsync
 {
-  public Func<HttpRequestMessage, Task<HttpResponseMessage?>> GetFakeResponseFromRequestAsync()
+    public Func<IServiceProvider, HttpRequestMessage, Task<HttpResponseMessage?>> GetFakeResponseFromRequestAsync()
     {
-        return async request =>
+        return async (sp, request) =>
         {
             if (request.RequestUri != null && request.RequestUri.ToString().EndsWith("/must-fake-2") && request.Method == HttpMethod.Get)
             {

--- a/src/FakeHandler.cs
+++ b/src/FakeHandler.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Fresp;
 
-internal class FakeHandler(FakeOptions options, string clientName, IHostEnvironment hostEnvironment, ILoggerFactory loggerFactory) : DelegatingHandler
+internal class FakeHandler(FakeOptions options, string clientName, IHostEnvironment hostEnvironment, IServiceProvider serviceProvider, ILoggerFactory loggerFactory) : DelegatingHandler
 {
     private readonly ILogger _logger = loggerFactory.CreateLogger(nameof(FakeHandler));
     private readonly bool _isProduction = hostEnvironment.IsProduction();
@@ -24,11 +24,11 @@ internal class FakeHandler(FakeOptions options, string clientName, IHostEnvironm
 
     private HttpResponseMessage SendWithFakeResponseFromRequest(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        foreach (var func in options.FakeResponseFromRequests)
+        foreach (var func in options.FakeResponsesFromRequests)
         {
             try
             {
-                var response = func(request);
+                var response = func(serviceProvider, request);
                 if (response is null)
                     continue;
 
@@ -51,7 +51,7 @@ internal class FakeHandler(FakeOptions options, string clientName, IHostEnvironm
         {
             try
             {
-                var response = await func(request);
+                var response = await func(serviceProvider, request);
                 if (response is null)
                     continue;
 
@@ -60,7 +60,7 @@ internal class FakeHandler(FakeOptions options, string clientName, IHostEnvironm
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "An error occurred while trying to get a async fake request for client {ClientName}.", clientName);
+                _logger.LogError(ex, "An error occurred while trying to get an async fake request for client {ClientName}.", clientName);
             }
         }
 
@@ -71,12 +71,22 @@ internal class FakeHandler(FakeOptions options, string clientName, IHostEnvironm
     private HttpResponseMessage SendWithFakeResponseFromResponse(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         var response = base.Send(request, cancellationToken);
+        return ProcessFakeResponseFromResponseSync(response);
+    }
 
-        foreach (var func in options.FakeResponseFromResponses)
+    private async Task<HttpResponseMessage> SendWithFakeResponseFromResponseAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var response = await base.SendAsync(request, cancellationToken);
+        return await ProcessFakeResponseFromResponseAsyncInternal(response);
+    }
+
+    private HttpResponseMessage ProcessFakeResponseFromResponseSync(HttpResponseMessage response)
+    {
+        foreach (var func in options.FakeResponsesFromResponses)
         {
             try
             {
-                var newResponse = func(response);
+                var newResponse = func(serviceProvider, response);
                 if (newResponse is null)
                     continue;
 
@@ -93,15 +103,13 @@ internal class FakeHandler(FakeOptions options, string clientName, IHostEnvironm
         return response;
     }
 
-    private async Task<HttpResponseMessage> SendWithFakeResponseFromResponseAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    private async Task<HttpResponseMessage> ProcessFakeResponseFromResponseAsyncInternal(HttpResponseMessage response)
     {
-        var response = await base.SendAsync(request, cancellationToken);
-
-        foreach (var func in options.FakeResponseFromResponsesAsync)
+        foreach (var func in options.FakeResponsesFromResponsesAsync)
         {
             try
             {
-                var newResponse = await func(response);
+                var newResponse = await func(serviceProvider, response);
                 if (newResponse is null)
                     continue;
 
@@ -110,7 +118,7 @@ internal class FakeHandler(FakeOptions options, string clientName, IHostEnvironm
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "An error occurred while trying to get a async fake response for client {ClientName}.", clientName);
+                _logger.LogError(ex, "An error occurred while trying to get an async fake response for client {ClientName}.", clientName);
             }
         }
 

--- a/src/FakeOptions.cs
+++ b/src/FakeOptions.cs
@@ -8,11 +8,10 @@ namespace Fresp;
 
 public class FakeOptions
 {
-    internal readonly List<Func<HttpResponseMessage, HttpResponseMessage?>> FakeResponseFromResponses = [];
-    internal readonly List<Func<HttpResponseMessage, Task<HttpResponseMessage?>>> FakeResponseFromResponsesAsync = [];
-
-    internal readonly List<Func<HttpRequestMessage, HttpResponseMessage?>> FakeResponseFromRequests = [];
-    internal readonly List<Func<HttpRequestMessage, Task<HttpResponseMessage?>>> FakeResponsesFromRequestsAsync = [];
+    internal readonly List<Func<IServiceProvider, HttpRequestMessage, HttpResponseMessage?>> FakeResponsesFromRequests = [];
+    internal readonly List<Func<IServiceProvider, HttpRequestMessage, Task<HttpResponseMessage?>>> FakeResponsesFromRequestsAsync = [];
+    internal readonly List<Func<IServiceProvider, HttpResponseMessage, HttpResponseMessage?>> FakeResponsesFromResponses = [];
+    internal readonly List<Func<IServiceProvider, HttpResponseMessage, Task<HttpResponseMessage?>>> FakeResponsesFromResponsesAsync = [];
 
     /// <summary>
     /// Enabled or disable the handler to return fake responses. Default is false.
@@ -30,58 +29,58 @@ public class FakeOptions
     public string? ClientName { get; set; } = null;
 
     /// <summary>
-    /// Add a fake sync <see cref="HttpResponseMessage"/> response to the handler that match <see cref="HttpRequestMessage"/>.
+    /// Add a fake sync <see cref="HttpResponseMessage"/> response to the handler that match <see cref="HttpRequestMessage"/> with access to <see cref="IServiceProvider"/>.
     /// </summary>
-    /// <param name="fake">A Func that takes an <see cref="HttpRequestMessage"/> and returns an <see cref="HttpResponseMessage"/> or null.</param>
-    public void AddFakeResponseFromRequest(Func<HttpRequestMessage, HttpResponseMessage?> fake)
-        => FakeResponseFromRequests.Add(fake);
+    /// <param name="fake">A Func that takes an <see cref="IServiceProvider"/>, an <see cref="HttpRequestMessage"/> and returns an <see cref="HttpResponseMessage"/> or null.</param>
+    public void AddFakeResponseFromRequest(Func<IServiceProvider, HttpRequestMessage, HttpResponseMessage?> fake)
+        => FakeResponsesFromRequests.Add(fake);
 
     /// <summary>
-    /// Add a fake async <see cref="HttpResponseMessage"/> response to the handler that match <see cref="HttpRequestMessage"/>.
+    /// Add a fake async <see cref="HttpResponseMessage"/> response to the handler that match <see cref="HttpRequestMessage"/> with access to <see cref="IServiceProvider"/>.
     /// </summary>
-    /// <param name="fake">A Func that takes an <see cref="HttpRequestMessage"/> and returns an <see cref="HttpResponseMessage"/> or null.</param>
-    public void AddFakeResponseFromRequestAsync(Func<HttpRequestMessage, Task<HttpResponseMessage?>> fake)
+    /// <param name="fake">A Func that takes an <see cref="IServiceProvider"/>, an <see cref="HttpRequestMessage"/> and returns a <see cref="Task{HttpResponseMessage?}"/> or null.</param>
+    public void AddFakeResponseFromRequestAsync(Func<IServiceProvider, HttpRequestMessage, Task<HttpResponseMessage?>> fake)
         => FakeResponsesFromRequestsAsync.Add(fake);
 
     /// <summary>
-    /// Add a fake sync <see cref="HttpResponseMessage"/> response to the handler that match <see cref="HttpRequestMessage"/>.
+    /// Add a fake sync <see cref="HttpResponseMessage"/> response to the handler that match <see cref="HttpRequestMessage"/> with access to DI.
     /// </summary>
     /// <typeparam name="T">The type of the fake response that implements <see cref="IFakeResponseFromRequest"/>.</typeparam>
     public void AddFakeResponseFromRequest<T>() where T : IFakeResponseFromRequest, new()
-        => FakeResponseFromRequests.Add(new T().GetFakeResponseFromRequest());
+        => FakeResponsesFromRequests.Add(new T().GetFakeResponseFromRequest());
 
     /// <summary>
-    /// Add a fake async <see cref="HttpResponseMessage"/> response to the handler that match <see cref="HttpRequestMessage"/>.
+    /// Add a fake async <see cref="HttpResponseMessage"/> response to the handler that match <see cref="HttpRequestMessage"/> with access to DI.
     /// </summary>
     /// <typeparam name="T">The type of the fake response that implements <see cref="IFakeResponseFromRequestAsync"/>.</typeparam>
     public void AddFakeResponseFromRequestAsync<T>() where T : IFakeResponseFromRequestAsync, new()
         => FakeResponsesFromRequestsAsync.Add(new T().GetFakeResponseFromRequestAsync());
 
     /// <summary>
-    /// Add a fake sync <see cref="HttpResponseMessage"/> response to the handler that match <see cref="HttpResponseMessage"/>.
+    /// Add a fake sync <see cref="HttpResponseMessage"/> response to the handler that match <see cref="HttpResponseMessage"/> with access to <see cref="IServiceProvider"/>.
+    /// </summary>
+    /// <param name="fake">A Func that takes an <see cref="IServiceProvider"/>, an <see cref="HttpResponseMessage"/> and returns an <see cref="HttpResponseMessage"/> or null.</param>
+    public void AddFakeResponseFromResponse(Func<IServiceProvider, HttpResponseMessage, HttpResponseMessage?> fake)
+        => FakeResponsesFromResponses.Add(fake);
+
+    /// <summary>
+    /// Add a fake async <see cref="HttpResponseMessage"/> response to the handler that match <see cref="HttpResponseMessage"/> with access to <see cref="IServiceProvider"/>.
+    /// </summary>
+    /// <param name="fake">A Func that takes an <see cref="IServiceProvider"/>, an <see cref="HttpResponseMessage"/> and returns a <see cref="Task{HttpResponseMessage?}"/> or null.</param>
+    public void AddFakeResponseFromResponseAsync(Func<IServiceProvider, HttpResponseMessage, Task<HttpResponseMessage?>> fake)
+        => FakeResponsesFromResponsesAsync.Add(fake);
+
+    /// <summary>
+    /// Add a fake sync <see cref="HttpResponseMessage"/> response to the handler that match <see cref="HttpResponseMessage"/> with access to DI.
     /// </summary>
     /// <typeparam name="T">The type of the fake response that implements <see cref="IFakeResponseFromResponse"/>.</typeparam>
     public void AddFakeResponseFromResponse<T>() where T : IFakeResponseFromResponse, new()
-        => FakeResponseFromResponses.Add(new T().GetFakeResponseFromResponse());
+        => FakeResponsesFromResponses.Add(new T().GetFakeResponseFromResponse());
 
     /// <summary>
-    /// Add a fake async <see cref="HttpResponseMessage"/> response to the handler that match <see cref="HttpResponseMessage"/>.
+    /// Add a fake async <see cref="HttpResponseMessage"/> response to the handler that match <see cref="HttpResponseMessage"/> with access to DI.
     /// </summary>
     /// <typeparam name="T">The type of the fake response that implements <see cref="IFakeResponseFromResponseAsync"/>.</typeparam>
     public void AddFakeResponseFromResponseAsync<T>() where T : IFakeResponseFromResponseAsync, new()
-        => FakeResponseFromResponsesAsync.Add(new T().GetFakeResponseFromResponseAsync());
-
-    /// <summary>
-    /// Add a fake sync <see cref="HttpResponseMessage"/> response to the handler that match <see cref="HttpResponseMessage"/>.
-    /// </summary>
-    /// <param name="fake">A Func that takes an <see cref="HttpResponseMessage"/> and returns an <see cref="HttpResponseMessage"/> or null.</param>
-    public void AddFakeResponseFromResponse(Func<HttpResponseMessage, HttpResponseMessage?> fake)
-        => FakeResponseFromResponses.Add(fake);
-
-    /// <summary>
-    /// Add a fake async <see cref="HttpResponseMessage"/> response to the handler that match <see cref="HttpResponseMessage"/>.
-    /// </summary>
-    /// <param name="fake">A Func that takes an <see cref="HttpResponseMessage"/> and returns an <see cref="HttpResponseMessage"/> or null.</param>
-    public void AddFakeResponseFromResponseAsync(Func<HttpResponseMessage, Task<HttpResponseMessage?>> fake)
-        => FakeResponseFromResponsesAsync.Add(fake);
+        => FakeResponsesFromResponsesAsync.Add(new T().GetFakeResponseFromResponseAsync());
 }

--- a/src/Fresp.csproj
+++ b/src/Fresp.csproj
@@ -5,7 +5,7 @@
 	<LangVersion>latest</LangVersion>
 	<ImplicitUsings>disable</ImplicitUsings>
 	<Nullable>enable</Nullable>
-	<Version>2.3.0</Version>
+	<Version>3.0.0</Version>
 	<Title>Fresp</Title>
 	<PackageId>Fresp</PackageId>
 	<Description>Fresp is a .NET NuGet package designed to provide fake responses for external APIs, aiding in testing environments such as DEV, UAT, HML, and QA.</Description>

--- a/src/HttpClientBuilderExtensions.cs
+++ b/src/HttpClientBuilderExtensions.cs
@@ -17,7 +17,7 @@ public static class HttpClientBuilderExtensions
     {
         var handlerOptions = new FakeOptions();
         options?.Invoke(handlerOptions);
-        builder.AddHttpMessageHandler(services => new FakeHandler(handlerOptions, handlerOptions.ClientName ?? builder.Name, services.GetRequiredService<IHostEnvironment>(), services.GetRequiredService<ILoggerFactory>()));
+        builder.AddHttpMessageHandler(services => new FakeHandler(handlerOptions, handlerOptions.ClientName ?? builder.Name, services.GetRequiredService<IHostEnvironment>(), services.GetRequiredService<IServiceProvider>(), services.GetRequiredService<ILoggerFactory>()));
 
         return builder;
     }

--- a/src/IFake.cs
+++ b/src/IFake.cs
@@ -1,25 +1,25 @@
-﻿using System.Net.Http;
-using System;
+﻿using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Fresp;
 
 public interface IFakeResponseFromRequest
 {
-    Func<HttpRequestMessage, HttpResponseMessage?> GetFakeResponseFromRequest();
+    Func<IServiceProvider, HttpRequestMessage, HttpResponseMessage?> GetFakeResponseFromRequest();
 }
 
 public interface IFakeResponseFromRequestAsync
 {
-    Func<HttpRequestMessage, Task<HttpResponseMessage?>> GetFakeResponseFromRequestAsync();
+    Func<IServiceProvider, HttpRequestMessage, Task<HttpResponseMessage?>> GetFakeResponseFromRequestAsync();
 }
 
 public interface IFakeResponseFromResponse
 {
-    Func<HttpResponseMessage, HttpResponseMessage?> GetFakeResponseFromResponse();
+    Func<IServiceProvider, HttpResponseMessage, HttpResponseMessage?> GetFakeResponseFromResponse();
 }
 
 public interface IFakeResponseFromResponseAsync
 {
-    Func<HttpResponseMessage, Task<HttpResponseMessage?>> GetFakeResponseFromResponseAsync();
+    Func<IServiceProvider, HttpResponseMessage, Task<HttpResponseMessage?>> GetFakeResponseFromResponseAsync();
 }

--- a/tests/Fresp.Tests/FakeHandlerTests.cs
+++ b/tests/Fresp.Tests/FakeHandlerTests.cs
@@ -11,15 +11,8 @@ public class FakeHandlerTests
     public async Task Send_InProduction_ShouldForwardRequest()
     {
         // Arrange
-        var options = new FakeOptions
-        {
-            Enabled = true,
-        };
-        var environment = Substitute.For<IHostEnvironment>();
-        environment.EnvironmentName.Returns(Environments.Production);
-        var logger = Substitute.For<ILoggerFactory>();
-        logger.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
-        var handler = new SutFakeHandler(options, "clienttest", environment, logger)
+        var options = new FakeOptions { Enabled = true };
+        var handler = new SutFakeHandler(options, "clienttest", CreateProductionEnvironment(), CreateServiceProvider(), CreateLoggerFactory())
         {
             InnerHandler = new MockDelegatingHandler()
         };
@@ -39,45 +32,20 @@ public class FakeHandlerTests
     public async Task Send_InProduction_WithForceProperty_ShouldReturnFromFake()
     {
         // Arrange
-        var options = new FakeOptions
-        {
-            Enabled = true,
-            ClientName = "otherName",
-            ForceUseInProduction = true,
-        };
-        options.AddFakeResponseFromRequest(request =>
+        var options = new FakeOptions { Enabled = true, ForceUseInProduction = true };
+        options.AddFakeResponseFromRequest((sp, request) =>
         {
             if (request.RequestUri != null && request.RequestUri.ToString().EndsWith("/must-fake") && request.Method == HttpMethod.Post)
-            {
-                return new HttpResponseMessage
-                {
-                    Content = new StringContent("Faked!"),
-                    StatusCode = HttpStatusCode.OK,
-                    ReasonPhrase = "Faked"
-                };
-            }
-
+                return new HttpResponseMessage { Content = new StringContent("Faked!"), StatusCode = HttpStatusCode.OK, ReasonPhrase = "Faked" };
             return null;
         });
-        options.AddFakeResponseFromRequest(request =>
+        options.AddFakeResponseFromRequest((sp, request) =>
         {
             if (request.RequestUri != null && request.RequestUri.ToString().EndsWith("/must-fake-2") && request.Method == HttpMethod.Get)
-            {
-                return new HttpResponseMessage
-                {
-                    Content = new StringContent("Faked2!"),
-                    StatusCode = HttpStatusCode.OK,
-                    ReasonPhrase = "Faked2"
-                };
-            }
-
+                return new HttpResponseMessage { Content = new StringContent("Faked2!"), StatusCode = HttpStatusCode.OK, ReasonPhrase = "Faked2" };
             return null;
         });
-        var environment = Substitute.For<IHostEnvironment>();
-        environment.EnvironmentName.Returns(Environments.Production);
-        var logger = Substitute.For<ILoggerFactory>();
-        logger.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
-        var handler = new SutFakeHandler(options, "clienttest", environment, logger)
+        var handler = new SutFakeHandler(options, "clienttest", CreateProductionEnvironment(), CreateServiceProvider(), CreateLoggerFactory())
         {
             InnerHandler = new MockDelegatingHandler()
         };
@@ -89,32 +57,21 @@ public class FakeHandlerTests
         var response2 = handler.Send(request2, CancellationToken.None);
 
         // Assert
-        response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.ReasonPhrase.Should().Be("Faked");
-        var content = await response.Content.ReadAsStringAsync();
-        content.Should().Be("Faked!");
+        (await response.Content.ReadAsStringAsync()).Should().Be("Faked!");
 
-        response2.Should().NotBeNull();
         response2.StatusCode.Should().Be(HttpStatusCode.OK);
         response2.ReasonPhrase.Should().Be("Faked2");
-        content = await response2.Content.ReadAsStringAsync();
-        content.Should().Be("Faked2!");
+        (await response2.Content.ReadAsStringAsync()).Should().Be("Faked2!");
     }
 
     [Fact]
     public async Task Send_WithDisabled_ShouldForwardRequest()
     {
         // Arrange
-        var options = new FakeOptions
-        {
-            Enabled = false
-        };
-        var environment = Substitute.For<IHostEnvironment>();
-        environment.EnvironmentName.Returns(Environments.Development);
-        var logger = Substitute.For<ILoggerFactory>();
-        logger.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
-        var handler = new SutFakeHandler(options, "clienttest", environment, logger)
+        var options = new FakeOptions { Enabled = false };
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), CreateServiceProvider(), CreateLoggerFactory())
         {
             InnerHandler = new MockDelegatingHandler()
         };
@@ -123,67 +80,8 @@ public class FakeHandlerTests
         var response = handler.Send(new HttpRequestMessage(), CancellationToken.None);
 
         // Assert
-        response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
-        response.ReasonPhrase.Should().Be("Mocked");
-        var content = await response.Content.ReadAsStringAsync();
-        content.Should().Be("Mocked!");
-    }
-
-    [Fact]
-    public async Task SendAsync_InProduction_ShouldForwardRequest()
-    {
-        // Arrange
-        var options = new FakeOptions
-        {
-            Enabled = true,
-        };
-        var environment = Substitute.For<IHostEnvironment>();
-        environment.EnvironmentName.Returns(Environments.Production);
-        var logger = Substitute.For<ILoggerFactory>();
-        logger.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
-        var handler = new SutFakeHandler(options, "clienttest", environment, logger)
-        {
-            InnerHandler = new MockDelegatingHandler()
-        };
-
-        // Act
-        var response = await handler.SendAsync(new HttpRequestMessage(), CancellationToken.None);
-
-        // Assert
-        response.Should().NotBeNull();
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
-        response.ReasonPhrase.Should().Be("Mocked");
-        var content = await response.Content.ReadAsStringAsync();
-        content.Should().Be("Mocked!");
-    }
-
-    [Fact]
-    public async Task SendAsync_WithDisabled_ShouldForwardRequest()
-    {
-        // Arrange
-        var options = new FakeOptions
-        {
-            Enabled = false
-        };
-        var environment = Substitute.For<IHostEnvironment>();
-        environment.EnvironmentName.Returns(Environments.Development);
-        var logger = Substitute.For<ILoggerFactory>();
-        logger.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
-        var handler = new SutFakeHandler(options, "clienttest", environment, logger)
-        {
-            InnerHandler = new MockDelegatingHandler()
-        };
-
-        // Act
-        var response = await handler.SendAsync(new HttpRequestMessage(), CancellationToken.None);
-
-        // Assert
-        response.Should().NotBeNull();
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
-        response.ReasonPhrase.Should().Be("Mocked");
-        var content = await response.Content.ReadAsStringAsync();
-        content.Should().Be("Mocked!");
+        (await response.Content.ReadAsStringAsync()).Should().Be("Mocked!");
     }
 
     [Fact]
@@ -191,264 +89,238 @@ public class FakeHandlerTests
     {
         // Arrange
         var options = new FakeOptions { Enabled = true };
-        var environment = Substitute.For<IHostEnvironment>();
-        environment.EnvironmentName.Returns(Environments.Development);
-        var logger = Substitute.For<ILoggerFactory>();
-        logger.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
-        var handler = new SutFakeHandler(options, "clienttest", environment, logger)
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), CreateServiceProvider(), CreateLoggerFactory())
         {
             InnerHandler = new MockDelegatingHandler()
         };
 
         // Act
         var response = handler.Send(new HttpRequestMessage(), CancellationToken.None);
+
         // Assert
-        response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
-        response.ReasonPhrase.Should().Be("Mocked");
-        var content = await response.Content.ReadAsStringAsync();
-        content.Should().Be("Mocked!");
+        (await response.Content.ReadAsStringAsync()).Should().Be("Mocked!");
     }
 
     [Fact]
     public async Task Send_WithFakeResponseFromRequest_ShouldReturnFromFake()
     {
         // Arrange
-        var options = new FakeOptions
-        {
-            Enabled = true,
-            ClientName = "otherName"
-        };
-        options.AddFakeResponseFromRequest(request =>
+        var options = new FakeOptions { Enabled = true };
+        options.AddFakeResponseFromRequest((sp, request) =>
         {
             if (request.RequestUri != null && request.RequestUri.ToString().EndsWith("/must-fake") && request.Method == HttpMethod.Post)
-            {
-                return new HttpResponseMessage
-                {
-                    Content = new StringContent("Faked!"),
-                    StatusCode = HttpStatusCode.OK,
-                    ReasonPhrase = "Faked"
-                };
-            }
-
+                return new HttpResponseMessage { Content = new StringContent("Faked!"), StatusCode = HttpStatusCode.OK, ReasonPhrase = "Faked" };
             return null;
         });
-        options.AddFakeResponseFromRequest(request =>
+        options.AddFakeResponseFromRequest((sp, request) =>
         {
             if (request.RequestUri != null && request.RequestUri.ToString().EndsWith("/must-fake-2") && request.Method == HttpMethod.Get)
-            {
-                return new HttpResponseMessage
-                {
-                    Content = new StringContent("Faked2!"),
-                    StatusCode = HttpStatusCode.OK,
-                    ReasonPhrase = "Faked2"
-                };
-            }
-
+                return new HttpResponseMessage { Content = new StringContent("Faked2!"), StatusCode = HttpStatusCode.OK, ReasonPhrase = "Faked2" };
             return null;
         });
-        var environment = Substitute.For<IHostEnvironment>();
-        environment.EnvironmentName.Returns(Environments.Development);
-        var logger = Substitute.For<ILoggerFactory>();
-        logger.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
-        var handler = new SutFakeHandler(options, "clienttest", environment, logger)
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), CreateServiceProvider(), CreateLoggerFactory())
         {
             InnerHandler = new MockDelegatingHandler()
         };
-        var request = new HttpRequestMessage(HttpMethod.Post, "/must-fake");
-        var request2 = new HttpRequestMessage(HttpMethod.Get, "/must-fake-2");
 
         // Act
-        var response = handler.Send(request, CancellationToken.None);
-        var response2 = handler.Send(request2, CancellationToken.None);
+        var response = handler.Send(new HttpRequestMessage(HttpMethod.Post, "/must-fake"), CancellationToken.None);
+        var response2 = handler.Send(new HttpRequestMessage(HttpMethod.Get, "/must-fake-2"), CancellationToken.None);
 
         // Assert
-        response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        response.ReasonPhrase.Should().Be("Faked");
-        var content = await response.Content.ReadAsStringAsync();
-        content.Should().Be("Faked!");
-
-        response2.Should().NotBeNull();
+        (await response.Content.ReadAsStringAsync()).Should().Be("Faked!");
         response2.StatusCode.Should().Be(HttpStatusCode.OK);
-        response2.ReasonPhrase.Should().Be("Faked2");
-        content = await response2.Content.ReadAsStringAsync();
-        content.Should().Be("Faked2!");
+        (await response2.Content.ReadAsStringAsync()).Should().Be("Faked2!");
     }
 
     [Fact]
     public async Task Send_WithFakeResponseFromResponse_ShouldReturnFromFake()
     {
         // Arrange
-        var options = new FakeOptions
-        {
-            Enabled = true
-        };
-        options.AddFakeResponseFromResponse(response =>
+        var options = new FakeOptions { Enabled = true };
+        options.AddFakeResponseFromResponse((sp, response) =>
         {
             if (response.StatusCode == HttpStatusCode.ServiceUnavailable)
-            {
-                return new HttpResponseMessage
-                {
-                    Content = new StringContent("Faked!"),
-                    StatusCode = HttpStatusCode.OK,
-                    ReasonPhrase = "Faked"
-                };
-            }
-
+                return new HttpResponseMessage { Content = new StringContent("Faked!"), StatusCode = HttpStatusCode.OK, ReasonPhrase = "Faked" };
             return null;
         });
-        var environment = Substitute.For<IHostEnvironment>();
-        environment.EnvironmentName.Returns(Environments.Development);
-        var logger = Substitute.For<ILogger>();
-        logger.IsEnabled(LogLevel.Debug).Returns(true);
-        var loggerFactory = Substitute.For<ILoggerFactory>();
-        loggerFactory.CreateLogger(Arg.Any<string>()).Returns(logger);
-        var handler = new SutFakeHandler(options, "clienttest", environment, loggerFactory)
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), CreateServiceProvider(), CreateDebugLoggerFactory())
         {
             InnerHandler = new MockResponseDelegatingHandler()
         };
-        var request = new HttpRequestMessage(HttpMethod.Post, "/must-fake");
 
         // Act
-        var response = handler.Send(request, CancellationToken.None);
+        var response = handler.Send(new HttpRequestMessage(HttpMethod.Post, "/must-fake"), CancellationToken.None);
 
         // Assert
-        response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        response.ReasonPhrase.Should().Be("Faked");
-        var content = await response.Content.ReadAsStringAsync();
-        content.Should().Be("Faked!");
+        (await response.Content.ReadAsStringAsync()).Should().Be("Faked!");
     }
 
     [Fact]
-    public async Task Send_WithFakeResponseFromRequest_ShouldReturnForward()
+    public async Task Send_WithFakeResponseFromRequest_ShouldForwardWhenNoMatch()
     {
         // Arrange
-        var options = new FakeOptions
-        {
-            Enabled = true
-        };
-        options.AddFakeResponseFromRequest(request =>
+        var options = new FakeOptions { Enabled = true };
+        options.AddFakeResponseFromRequest((sp, request) =>
         {
             if (request.RequestUri?.AbsolutePath == "/must-fake" && request.Method == HttpMethod.Post)
-            {
-                return new HttpResponseMessage
-                {
-                    Content = new StringContent("Faked!"),
-                    StatusCode = HttpStatusCode.OK,
-                    ReasonPhrase = "Faked"
-                };
-            }
-
+                return new HttpResponseMessage { Content = new StringContent("Faked!"), StatusCode = HttpStatusCode.OK };
             return null;
         });
-        options.AddFakeResponseFromRequest(request =>
-        {
-            if (request.RequestUri?.AbsolutePath == "/must-fake-2" && request.Method == HttpMethod.Get)
-            {
-                return new HttpResponseMessage
-                {
-                    Content = new StringContent("Faked2!"),
-                    StatusCode = HttpStatusCode.OK,
-                    ReasonPhrase = "Faked2"
-                };
-            }
-
-            return null;
-        });
-        var environment = Substitute.For<IHostEnvironment>();
-        environment.EnvironmentName.Returns(Environments.Development);
-        var logger = Substitute.For<ILoggerFactory>();
-        logger.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
-        var handler = new SutFakeHandler(options, "clienttest", environment, logger)
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), CreateServiceProvider(), CreateLoggerFactory())
         {
             InnerHandler = new MockDelegatingHandler()
         };
-        var request = new HttpRequestMessage(HttpMethod.Post, "/must-not-fake");
-        var request2 = new HttpRequestMessage(HttpMethod.Get, "/must-not-fake-2");
 
         // Act
-        var response = handler.Send(request, CancellationToken.None);
-        var response2 = handler.Send(request2, CancellationToken.None);
+        var response = handler.Send(new HttpRequestMessage(HttpMethod.Post, "/must-not-fake"), CancellationToken.None);
 
         // Assert
-        response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
-        response.ReasonPhrase.Should().Be("Mocked");
-        var content = await response.Content.ReadAsStringAsync();
-        content.Should().Be("Mocked!");
-
-        response2.Should().NotBeNull();
-        response2.StatusCode.Should().Be(HttpStatusCode.Accepted);
-        response2.ReasonPhrase.Should().Be("Mocked");
-        content = await response2.Content.ReadAsStringAsync();
-        content.Should().Be("Mocked!");
+        (await response.Content.ReadAsStringAsync()).Should().Be("Mocked!");
     }
 
     [Fact]
-    public async Task Send_WithFakeResponseFromResponse_ShouldReturnForward()
+    public async Task Send_WithFakeResponseFromResponse_ShouldForwardWhenNoMatch()
     {
         // Arrange
-        var options = new FakeOptions
+        var options = new FakeOptions { Enabled = true };
+        options.AddFakeResponseFromResponse((sp, response) =>
         {
-            Enabled = true
-        };
-        options.AddFakeResponseFromResponse(response =>
-        {
-        if (response.StatusCode == HttpStatusCode.InternalServerError)
-            {
-                return new HttpResponseMessage
-                {
-                    Content = new StringContent("Faked!"),
-                    StatusCode = HttpStatusCode.OK,
-                    ReasonPhrase = "Faked"
-                };
-            }
-
+            if (response.StatusCode == HttpStatusCode.InternalServerError)
+                return new HttpResponseMessage { Content = new StringContent("Faked!"), StatusCode = HttpStatusCode.OK };
             return null;
         });
-        options.AddFakeResponseFromResponse(response =>
-        {
-            if (response.StatusCode == HttpStatusCode.GatewayTimeout)
-            {
-                return new HttpResponseMessage
-                {
-                    Content = new StringContent("Faked2!"),
-                    StatusCode = HttpStatusCode.OK,
-                    ReasonPhrase = "Faked2"
-                };
-            }
-
-            return null;
-        });
-        var environment = Substitute.For<IHostEnvironment>();
-        environment.EnvironmentName.Returns(Environments.Development);
-        var logger = Substitute.For<ILoggerFactory>();
-        logger.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
-        var handler = new SutFakeHandler(options, "clienttest", environment, logger)
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), CreateServiceProvider(), CreateLoggerFactory())
         {
             InnerHandler = new MockResponseDelegatingHandler()
         };
-        var request = new HttpRequestMessage(HttpMethod.Post, "/must-not-fake");
-        var request2 = new HttpRequestMessage(HttpMethod.Get, "/must-not-fake-2");
 
         // Act
-        var response = handler.Send(request, CancellationToken.None);
-        var response2 = handler.Send(request2, CancellationToken.None);
+        var response = handler.Send(new HttpRequestMessage(HttpMethod.Post, "/must-not-fake"), CancellationToken.None);
 
         // Assert
-        response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
-        response.ReasonPhrase.Should().Be("Mocked");
-        var content = await response.Content.ReadAsStringAsync();
-        content.Should().Be("Mocked!");
+        (await response.Content.ReadAsStringAsync()).Should().Be("Mocked!");
+    }
 
-        response2.Should().NotBeNull();
-        response2.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
-        response2.ReasonPhrase.Should().Be("Mocked");
-        content = await response2.Content.ReadAsStringAsync();
-        content.Should().Be("Mocked!");
+    [Fact]
+    public async Task Send_WithFakeResponseFromRequest_ShouldThrowAndForward()
+    {
+        // Arrange
+        var options = new FakeOptions { Enabled = true };
+        options.AddFakeResponseFromRequest((sp, request) => throw new Exception("Fake exception"));
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), CreateServiceProvider(), CreateLoggerFactory())
+        {
+            InnerHandler = new MockDelegatingHandler()
+        };
+
+        // Act
+        var response = handler.Send(new HttpRequestMessage(), CancellationToken.None);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        (await response.Content.ReadAsStringAsync()).Should().Be("Mocked!");
+    }
+
+    [Fact]
+    public async Task Send_WithFakeResponseFromResponse_ShouldThrowAndForward()
+    {
+        // Arrange
+        var options = new FakeOptions { Enabled = true };
+        options.AddFakeResponseFromResponse((sp, response) => throw new Exception("Fake exception"));
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), CreateServiceProvider(), CreateLoggerFactory())
+        {
+            InnerHandler = new MockResponseDelegatingHandler()
+        };
+
+        // Act
+        var response = handler.Send(new HttpRequestMessage(), CancellationToken.None);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        (await response.Content.ReadAsStringAsync()).Should().Be("Mocked!");
+    }
+
+    [Fact]
+    public async Task Send_WithFakeResponseFromRequest_ClassBased_ShouldReturnFromFake()
+    {
+        // Arrange
+        var options = new FakeOptions { Enabled = true };
+        options.AddFakeResponseFromRequest<MockFakeResponseFromRequest>();
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), CreateServiceProvider(), CreateLoggerFactory())
+        {
+            InnerHandler = new MockDelegatingHandler()
+        };
+
+        // Act
+        var response = handler.Send(new HttpRequestMessage(HttpMethod.Post, "/must-fake"), CancellationToken.None);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).Should().Be("Faked!");
+    }
+
+    [Fact]
+    public async Task Send_WithFakeResponseFromResponse_ClassBased_ShouldReturnFromFake()
+    {
+        // Arrange
+        var options = new FakeOptions { Enabled = true };
+        options.AddFakeResponseFromResponse<MockFakeResponseFromResponse>();
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), CreateServiceProvider(), CreateDebugLoggerFactory())
+        {
+            InnerHandler = new MockResponseDelegatingHandler()
+        };
+
+        // Act
+        var response = handler.Send(new HttpRequestMessage(HttpMethod.Post, "/must-fake"), CancellationToken.None);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).Should().Be("Faked!");
+    }
+
+    // ============================================================
+    // SendAsync - Async tests
+    // ============================================================
+
+    [Fact]
+    public async Task SendAsync_InProduction_ShouldForwardRequest()
+    {
+        // Arrange
+        var options = new FakeOptions { Enabled = true };
+        var handler = new SutFakeHandler(options, "clienttest", CreateProductionEnvironment(), CreateServiceProvider(), CreateLoggerFactory())
+        {
+            InnerHandler = new MockDelegatingHandler()
+        };
+
+        // Act
+        var response = await handler.SendAsync(new HttpRequestMessage(), CancellationToken.None);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        (await response.Content.ReadAsStringAsync()).Should().Be("Mocked!");
+    }
+
+    [Fact]
+    public async Task SendAsync_WithDisabled_ShouldForwardRequest()
+    {
+        // Arrange
+        var options = new FakeOptions { Enabled = false };
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), CreateServiceProvider(), CreateLoggerFactory())
+        {
+            InnerHandler = new MockDelegatingHandler()
+        };
+
+        // Act
+        var response = await handler.SendAsync(new HttpRequestMessage(), CancellationToken.None);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        (await response.Content.ReadAsStringAsync()).Should().Be("Mocked!");
     }
 
     [Fact]
@@ -456,379 +328,155 @@ public class FakeHandlerTests
     {
         // Arrange
         var options = new FakeOptions { Enabled = true };
-        var environment = Substitute.For<IHostEnvironment>();
-        environment.EnvironmentName.Returns(Environments.Development);
-        var logger = Substitute.For<ILoggerFactory>();
-        logger.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
-        var handler = new SutFakeHandler(options, "clienttest", environment, logger)
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), CreateServiceProvider(), CreateLoggerFactory())
         {
             InnerHandler = new MockDelegatingHandler()
         };
 
         // Act
         var response = await handler.SendAsync(new HttpRequestMessage(), CancellationToken.None);
+
         // Assert
-        response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
-        response.ReasonPhrase.Should().Be("Mocked");
-        var content = await response.Content.ReadAsStringAsync();
-        content.Should().Be("Mocked!");
+        (await response.Content.ReadAsStringAsync()).Should().Be("Mocked!");
     }
 
     [Fact]
     public async Task SendAsync_WithFakeResponseFromRequest_ShouldReturnFromFake()
     {
         // Arrange
-        var options = new FakeOptions
-        {
-            Enabled = true
-        };
-        options.AddFakeResponseFromRequestAsync(request =>
+        var options = new FakeOptions { Enabled = true };
+        options.AddFakeResponseFromRequestAsync(async (sp, request) =>
         {
             if (request.RequestUri != null && request.RequestUri.ToString().EndsWith("/must-fake") && request.Method == HttpMethod.Post)
-            {
-                return Task.FromResult<HttpResponseMessage?>(new HttpResponseMessage
-                {
-                    Content = new StringContent("Faked!"),
-                    StatusCode = HttpStatusCode.OK,
-                    ReasonPhrase = "Faked"
-                });
-            }
-
-            return Task.FromResult<HttpResponseMessage?>(null);
+                return await Task.FromResult<HttpResponseMessage?>(new HttpResponseMessage { Content = new StringContent("Faked!"), StatusCode = HttpStatusCode.OK, ReasonPhrase = "Faked" });
+            return await Task.FromResult<HttpResponseMessage?>(null);
         });
-        options.AddFakeResponseFromRequestAsync(request =>
+        options.AddFakeResponseFromRequestAsync(async (sp, request) =>
         {
             if (request.RequestUri != null && request.RequestUri.ToString().EndsWith("/must-fake-2") && request.Method == HttpMethod.Get)
-            {
-                return Task.FromResult<HttpResponseMessage?>(new HttpResponseMessage
-                {
-                    Content = new StringContent("Faked2!"),
-                    StatusCode = HttpStatusCode.OK,
-                    ReasonPhrase = "Faked2"
-                });
-            }
-
-            return Task.FromResult((HttpResponseMessage?)null);
+                return await Task.FromResult<HttpResponseMessage?>(new HttpResponseMessage { Content = new StringContent("Faked2!"), StatusCode = HttpStatusCode.OK, ReasonPhrase = "Faked2" });
+            return await Task.FromResult<HttpResponseMessage?>(null);
         });
-        var environment = Substitute.For<IHostEnvironment>();
-        environment.EnvironmentName.Returns(Environments.Development);
-        var logger = Substitute.For<ILoggerFactory>();
-        logger.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
-        var handler = new SutFakeHandler(options, "clienttest", environment, logger)
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), CreateServiceProvider(), CreateLoggerFactory())
         {
             InnerHandler = new MockDelegatingHandler()
         };
-        var request = new HttpRequestMessage(HttpMethod.Post, "/must-fake");
-        var request2 = new HttpRequestMessage(HttpMethod.Get, "/must-fake-2");
 
         // Act
-        var response = await handler.SendAsync(request, CancellationToken.None);
-        var response2 = await handler.SendAsync(request2, CancellationToken.None);
+        var response = await handler.SendAsync(new HttpRequestMessage(HttpMethod.Post, "/must-fake"), CancellationToken.None);
+        var response2 = await handler.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/must-fake-2"), CancellationToken.None);
 
         // Assert
-        response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        response.ReasonPhrase.Should().Be("Faked");
-        var content = await response.Content.ReadAsStringAsync();
-        content.Should().Be("Faked!");
-
-        response2.Should().NotBeNull();
+        (await response.Content.ReadAsStringAsync()).Should().Be("Faked!");
         response2.StatusCode.Should().Be(HttpStatusCode.OK);
-        response2.ReasonPhrase.Should().Be("Faked2");
-        content = await response2.Content.ReadAsStringAsync();
-        content.Should().Be("Faked2!");
+        (await response2.Content.ReadAsStringAsync()).Should().Be("Faked2!");
     }
 
     [Fact]
-    public async Task SendAsync_InProduction_WithForceProperty_WithFakeResponseFromRequest_ShouldReturnFromFake()
+    public async Task SendAsync_InProduction_WithForceProperty_ShouldReturnFromFake()
     {
         // Arrange
-        var options = new FakeOptions
-        {
-            Enabled = true,
-            ForceUseInProduction = true,
-        };
-        options.AddFakeResponseFromRequestAsync(request =>
+        var options = new FakeOptions { Enabled = true, ForceUseInProduction = true };
+        options.AddFakeResponseFromRequestAsync(async (sp, request) =>
         {
             if (request.RequestUri != null && request.RequestUri.ToString().EndsWith("/must-fake") && request.Method == HttpMethod.Post)
-            {
-                return Task.FromResult<HttpResponseMessage?>(new HttpResponseMessage
-                {
-                    Content = new StringContent("Faked!"),
-                    StatusCode = HttpStatusCode.OK,
-                    ReasonPhrase = "Faked"
-                });
-            }
-
-            return Task.FromResult<HttpResponseMessage?>(null);
+                return await Task.FromResult<HttpResponseMessage?>(new HttpResponseMessage { Content = new StringContent("Faked!"), StatusCode = HttpStatusCode.OK });
+            return await Task.FromResult<HttpResponseMessage?>(null);
         });
-        options.AddFakeResponseFromRequestAsync(request =>
-        {
-            if (request.RequestUri != null && request.RequestUri.ToString().EndsWith("/must-fake-2") && request.Method == HttpMethod.Get)
-            {
-                return Task.FromResult<HttpResponseMessage?>(new HttpResponseMessage
-                {
-                    Content = new StringContent("Faked2!"),
-                    StatusCode = HttpStatusCode.OK,
-                    ReasonPhrase = "Faked2"
-                });
-            }
-
-            return Task.FromResult((HttpResponseMessage?)null);
-        });
-        var environment = Substitute.For<IHostEnvironment>();
-        environment.EnvironmentName.Returns(Environments.Production);
-        var logger = Substitute.For<ILoggerFactory>();
-        logger.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
-        var handler = new SutFakeHandler(options, "clienttest", environment, logger)
+        var handler = new SutFakeHandler(options, "clienttest", CreateProductionEnvironment(), CreateServiceProvider(), CreateLoggerFactory())
         {
             InnerHandler = new MockDelegatingHandler()
         };
-        var request = new HttpRequestMessage(HttpMethod.Post, "/must-fake");
-        var request2 = new HttpRequestMessage(HttpMethod.Get, "/must-fake-2");
 
         // Act
-        var response = await handler.SendAsync(request, CancellationToken.None);
-        var response2 = await handler.SendAsync(request2, CancellationToken.None);
+        var response = await handler.SendAsync(new HttpRequestMessage(HttpMethod.Post, "/must-fake"), CancellationToken.None);
 
         // Assert
-        response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        response.ReasonPhrase.Should().Be("Faked");
-        var content = await response.Content.ReadAsStringAsync();
-        content.Should().Be("Faked!");
-
-        response2.Should().NotBeNull();
-        response2.StatusCode.Should().Be(HttpStatusCode.OK);
-        response2.ReasonPhrase.Should().Be("Faked2");
-        content = await response2.Content.ReadAsStringAsync();
-        content.Should().Be("Faked2!");
+        (await response.Content.ReadAsStringAsync()).Should().Be("Faked!");
     }
 
     [Fact]
     public async Task SendAsync_WithFakeResponseFromResponse_ShouldReturnFromFake()
     {
         // Arrange
-        var options = new FakeOptions
-        {
-            Enabled = true
-        };
-        options.AddFakeResponseFromResponseAsync(response =>
+        var options = new FakeOptions { Enabled = true };
+        options.AddFakeResponseFromResponseAsync(async (sp, response) =>
         {
             if (response.StatusCode == HttpStatusCode.ServiceUnavailable)
-            {
-                return Task.FromResult<HttpResponseMessage?>(new HttpResponseMessage
-                {
-                    Content = new StringContent("Faked!"),
-                    StatusCode = HttpStatusCode.OK,
-                    ReasonPhrase = "Faked"
-                });
-            }
-
-            return Task.FromResult<HttpResponseMessage?>(null);
+                return await Task.FromResult<HttpResponseMessage?>(new HttpResponseMessage { Content = new StringContent("Faked!"), StatusCode = HttpStatusCode.OK });
+            return await Task.FromResult<HttpResponseMessage?>(null);
         });
-        var environment = Substitute.For<IHostEnvironment>();
-        environment.EnvironmentName.Returns(Environments.Development);
-        var logger = Substitute.For<ILoggerFactory>();
-        logger.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
-        var handler = new SutFakeHandler(options, "clienttest", environment, logger)
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), CreateServiceProvider(), CreateLoggerFactory())
         {
             InnerHandler = new MockResponseDelegatingHandler()
         };
-        var request = new HttpRequestMessage(HttpMethod.Post, "/must-fake");
 
         // Act
-        var response = await handler.SendAsync(request, CancellationToken.None);
+        var response = await handler.SendAsync(new HttpRequestMessage(HttpMethod.Post, "/must-fake"), CancellationToken.None);
 
         // Assert
-        response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        response.ReasonPhrase.Should().Be("Faked");
-        var content = await response.Content.ReadAsStringAsync();
-        content.Should().Be("Faked!");
+        (await response.Content.ReadAsStringAsync()).Should().Be("Faked!");
     }
 
     [Fact]
-    public async Task SendAsync_WithFakeResponseFromRequest_ShouldReturnForward()
+    public async Task SendAsync_WithFakeResponseFromRequest_ShouldForwardWhenNoMatch()
     {
         // Arrange
-        var options = new FakeOptions
-        {
-            Enabled = true
-        };
-        options.AddFakeResponseFromRequestAsync(request =>
+        var options = new FakeOptions { Enabled = true };
+        options.AddFakeResponseFromRequestAsync(async (sp, request) =>
         {
             if (request.RequestUri != null && request.RequestUri.ToString().EndsWith("/must-fake") && request.Method == HttpMethod.Post)
-            {
-                return Task.FromResult<HttpResponseMessage?>(new HttpResponseMessage
-                {
-                    Content = new StringContent("Faked!"),
-                    StatusCode = HttpStatusCode.OK,
-                    ReasonPhrase = "Faked"
-                });
-            }
-
-            return Task.FromResult((HttpResponseMessage?)null);
+                return await Task.FromResult<HttpResponseMessage?>(new HttpResponseMessage { Content = new StringContent("Faked!"), StatusCode = HttpStatusCode.OK });
+            return await Task.FromResult<HttpResponseMessage?>(null);
         });
-        options.AddFakeResponseFromRequestAsync(request =>
-        {
-            if (request.RequestUri != null && request.RequestUri.ToString().EndsWith("/must-fake-2") && request.Method == HttpMethod.Get)
-            {
-                return Task.FromResult((HttpResponseMessage?)new HttpResponseMessage
-                {
-                    Content = new StringContent("Faked2!"),
-                    StatusCode = HttpStatusCode.OK,
-                    ReasonPhrase = "Faked2"
-                });
-            }
-
-            return Task.FromResult<HttpResponseMessage?>(null);
-        });
-        var environment = Substitute.For<IHostEnvironment>();
-        environment.EnvironmentName.Returns(Environments.Development);
-        var logger = Substitute.For<ILoggerFactory>();
-        logger.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
-        var handler = new SutFakeHandler(options, "clienttest", environment, logger)
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), CreateServiceProvider(), CreateLoggerFactory())
         {
             InnerHandler = new MockDelegatingHandler()
         };
-        var request = new HttpRequestMessage(HttpMethod.Post, "/must-not-fake");
-        var request2 = new HttpRequestMessage(HttpMethod.Get, "/must-not-fake-2");
 
         // Act
-        var response = await handler.SendAsync(request, CancellationToken.None);
-        var response2 = await handler.SendAsync(request2, CancellationToken.None);
+        var response = await handler.SendAsync(new HttpRequestMessage(HttpMethod.Post, "/must-not-fake"), CancellationToken.None);
 
         // Assert
-        response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
-        response.ReasonPhrase.Should().Be("Mocked");
-        var content = await response.Content.ReadAsStringAsync();
-        content.Should().Be("Mocked!");
-
-        response2.Should().NotBeNull();
-        response2.StatusCode.Should().Be(HttpStatusCode.Accepted);
-        response2.ReasonPhrase.Should().Be("Mocked");
-        content = await response2.Content.ReadAsStringAsync();
-        content.Should().Be("Mocked!");
+        (await response.Content.ReadAsStringAsync()).Should().Be("Mocked!");
     }
 
     [Fact]
-    public async Task SendAsync_WithFakeResponseFromResponse_ShouldReturnForward()
+    public async Task SendAsync_WithFakeResponseFromResponse_ShouldForwardWhenNoMatch()
     {
         // Arrange
-        var options = new FakeOptions
-        {
-            Enabled = true
-        };
-        options.AddFakeResponseFromResponseAsync(response =>
+        var options = new FakeOptions { Enabled = true };
+        options.AddFakeResponseFromResponseAsync(async (sp, response) =>
         {
             if (response.StatusCode == HttpStatusCode.BadRequest)
-            {
-                return Task.FromResult<HttpResponseMessage?>(new HttpResponseMessage
-                {
-                    Content = new StringContent("Faked!"),
-                    StatusCode = HttpStatusCode.OK,
-                    ReasonPhrase = "Faked"
-                });
-            }
-
-            return Task.FromResult((HttpResponseMessage?)null);
+                return await Task.FromResult<HttpResponseMessage?>(new HttpResponseMessage { Content = new StringContent("Faked!"), StatusCode = HttpStatusCode.OK });
+            return await Task.FromResult<HttpResponseMessage?>(null);
         });
-        var environment = Substitute.For<IHostEnvironment>();
-        environment.EnvironmentName.Returns(Environments.Development);
-        var logger = Substitute.For<ILoggerFactory>();
-        logger.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
-        var handler = new SutFakeHandler(options, "clienttest", environment, logger)
-        {
-            InnerHandler = new MockResponseDelegatingHandler()
-        };
-        var request = new HttpRequestMessage(HttpMethod.Post, "/must-not-fake");
-
-        // Act
-        var response = await handler.SendAsync(request, CancellationToken.None);
-
-        // Assert
-        response.Should().NotBeNull();
-        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
-        response.ReasonPhrase.Should().Be("Mocked");
-        var content = await response.Content.ReadAsStringAsync();
-        content.Should().Be("Mocked!");
-    }
-
-    [Fact]
-    public async Task Send_WithFakeResponseFromRequest_ShouldThrowsAndForwardRequest()
-    {
-        // Arrange
-        var options = new FakeOptions
-        {
-            Enabled = true
-        };
-        options.AddFakeResponseFromRequest(_ => throw new Exception("Fake exception"));
-        var environment = Substitute.For<IHostEnvironment>();
-        environment.EnvironmentName.Returns(Environments.Development);
-        var logger = Substitute.For<ILoggerFactory>();
-        logger.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
-        var handler = new SutFakeHandler(options, "clienttest", environment, logger)
-        {
-            InnerHandler = new MockDelegatingHandler()
-        };
-
-        // Act
-        var response = handler.Send(new HttpRequestMessage(), CancellationToken.None);
-
-        // Assert
-        response.Should().NotBeNull();
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
-        response.ReasonPhrase.Should().Be("Mocked");
-        var content = await response.Content.ReadAsStringAsync();
-        content.Should().Be("Mocked!");
-    }
-
-    [Fact]
-    public async Task Send_WithFakeResponseFromResponse_ShouldThrowsAndForwardResponse()
-    {
-        // Arrange
-        var options = new FakeOptions
-        {
-            Enabled = true
-        };
-        options.AddFakeResponseFromResponse(_ => throw new Exception("Fake exception"));
-        var environment = Substitute.For<IHostEnvironment>();
-        environment.EnvironmentName.Returns(Environments.Development);
-        var logger = Substitute.For<ILoggerFactory>();
-        logger.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
-        var handler = new SutFakeHandler(options, "clienttest", environment, logger)
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), CreateServiceProvider(), CreateLoggerFactory())
         {
             InnerHandler = new MockResponseDelegatingHandler()
         };
 
         // Act
-        var response = handler.Send(new HttpRequestMessage(), CancellationToken.None);
+        var response = await handler.SendAsync(new HttpRequestMessage(HttpMethod.Post, "/must-not-fake"), CancellationToken.None);
 
         // Assert
-        response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
-        response.ReasonPhrase.Should().Be("Mocked");
-        var content = await response.Content.ReadAsStringAsync();
-        content.Should().Be("Mocked!");
+        (await response.Content.ReadAsStringAsync()).Should().Be("Mocked!");
     }
 
     [Fact]
-    public async Task SendAsync_WithFakeResponseFromRequest_ShouldThrowsAndForwardRequest()
+    public async Task SendAsync_WithFakeResponseFromRequest_ShouldThrowAndForward()
     {
         // Arrange
-        var options = new FakeOptions
-        {
-            Enabled = true
-        };
-        options.AddFakeResponseFromRequestAsync(_ => throw new Exception("Fake exception"));
-        var environment = Substitute.For<IHostEnvironment>();
-        environment.EnvironmentName.Returns(Environments.Development);
-        var logger = Substitute.For<ILoggerFactory>();
-        logger.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
-        var handler = new SutFakeHandler(options, "clienttest", environment, logger)
+        var options = new FakeOptions { Enabled = true };
+        options.AddFakeResponseFromRequestAsync((sp, request) => throw new Exception("Fake exception"));
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), CreateServiceProvider(), CreateLoggerFactory())
         {
             InnerHandler = new MockDelegatingHandler()
         };
@@ -837,27 +485,17 @@ public class FakeHandlerTests
         var response = await handler.SendAsync(new HttpRequestMessage(), CancellationToken.None);
 
         // Assert
-        response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
-        response.ReasonPhrase.Should().Be("Mocked");
-        var content = await response.Content.ReadAsStringAsync();
-        content.Should().Be("Mocked!");
+        (await response.Content.ReadAsStringAsync()).Should().Be("Mocked!");
     }
 
     [Fact]
-    public async Task SendAsync_WithFakeResponseFromResponse_ShouldThrowsAndForwardResponse()
+    public async Task SendAsync_WithFakeResponseFromResponse_ShouldThrowAndForward()
     {
         // Arrange
-        var options = new FakeOptions
-        {
-            Enabled = true
-        };
-        options.AddFakeResponseFromResponseAsync(_ => throw new Exception("Fake exception"));
-        var environment = Substitute.For<IHostEnvironment>();
-        environment.EnvironmentName.Returns(Environments.Development);
-        var logger = Substitute.For<ILoggerFactory>();
-        logger.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
-        var handler = new SutFakeHandler(options, "clienttest", environment, logger)
+        var options = new FakeOptions { Enabled = true };
+        options.AddFakeResponseFromResponseAsync((sp, response) => throw new Exception("Fake exception"));
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), CreateServiceProvider(), CreateLoggerFactory())
         {
             InnerHandler = new MockResponseDelegatingHandler()
         };
@@ -866,10 +504,182 @@ public class FakeHandlerTests
         var response = await handler.SendAsync(new HttpRequestMessage(), CancellationToken.None);
 
         // Assert
-        response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
-        response.ReasonPhrase.Should().Be("Mocked");
-        var content = await response.Content.ReadAsStringAsync();
-        content.Should().Be("Mocked!");
+        (await response.Content.ReadAsStringAsync()).Should().Be("Mocked!");
+    }
+
+    [Fact]
+    public async Task SendAsync_WithFakeResponseFromRequest_ClassBased_ShouldReturnFromFake()
+    {
+        // Arrange
+        var options = new FakeOptions { Enabled = true };
+        options.AddFakeResponseFromRequestAsync<MockFakeResponseFromRequestAsync>();
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), CreateServiceProvider(), CreateLoggerFactory())
+        {
+            InnerHandler = new MockDelegatingHandler()
+        };
+
+        // Act
+        var response = await handler.SendAsync(new HttpRequestMessage(HttpMethod.Post, "/must-fake"), CancellationToken.None);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).Should().Be("Faked!");
+    }
+
+    [Fact]
+    public async Task SendAsync_WithFakeResponseFromResponse_ClassBased_ShouldReturnFromFake()
+    {
+        // Arrange
+        var options = new FakeOptions { Enabled = true };
+        options.AddFakeResponseFromResponseAsync<MockFakeResponseFromResponseAsync>();
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), CreateServiceProvider(), CreateLoggerFactory())
+        {
+            InnerHandler = new MockResponseDelegatingHandler()
+        };
+
+        // Act
+        var response = await handler.SendAsync(new HttpRequestMessage(HttpMethod.Post, "/must-fake"), CancellationToken.None);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).Should().Be("Faked!");
+    }
+
+    // ============================================================
+    // DI-specific tests (verifying IServiceProvider is passed)
+    // ============================================================
+
+    [Fact]
+    public async Task Send_WithFakeResponseFromRequest_ShouldReceiveServiceProvider()
+    {
+        // Arrange
+        var options = new FakeOptions { Enabled = true };
+        IServiceProvider? receivedSp = null;
+        options.AddFakeResponseFromRequest((sp, request) =>
+        {
+            receivedSp = sp;
+            return new HttpResponseMessage { Content = new StringContent("DI!"), StatusCode = HttpStatusCode.OK };
+        });
+        var serviceProvider = CreateServiceProvider();
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), serviceProvider, CreateLoggerFactory())
+        {
+            InnerHandler = new MockDelegatingHandler()
+        };
+
+        // Act
+        var response = handler.Send(new HttpRequestMessage(), CancellationToken.None);
+
+        // Assert
+        receivedSp.Should().BeSameAs(serviceProvider);
+        (await response.Content.ReadAsStringAsync()).Should().Be("DI!");
+    }
+
+    [Fact]
+    public async Task SendAsync_WithFakeResponseFromRequestAsync_ShouldReceiveServiceProvider()
+    {
+        // Arrange
+        var options = new FakeOptions { Enabled = true };
+        IServiceProvider? receivedSp = null;
+        options.AddFakeResponseFromRequestAsync(async (sp, request) =>
+        {
+            receivedSp = sp;
+            return await Task.FromResult<HttpResponseMessage?>(new HttpResponseMessage { Content = new StringContent("DIAsync!"), StatusCode = HttpStatusCode.OK });
+        });
+        var serviceProvider = CreateServiceProvider();
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), serviceProvider, CreateLoggerFactory())
+        {
+            InnerHandler = new MockDelegatingHandler()
+        };
+
+        // Act
+        var response = await handler.SendAsync(new HttpRequestMessage(), CancellationToken.None);
+
+        // Assert
+        receivedSp.Should().BeSameAs(serviceProvider);
+        (await response.Content.ReadAsStringAsync()).Should().Be("DIAsync!");
+    }
+
+    [Fact]
+    public async Task Send_WithFakeResponseFromResponse_ShouldReceiveServiceProvider()
+    {
+        // Arrange
+        var options = new FakeOptions { Enabled = true };
+        IServiceProvider? receivedSp = null;
+        options.AddFakeResponseFromResponse((sp, response) =>
+        {
+            receivedSp = sp;
+            return new HttpResponseMessage { Content = new StringContent("DIResponse!"), StatusCode = HttpStatusCode.OK };
+        });
+        var serviceProvider = CreateServiceProvider();
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), serviceProvider, CreateDebugLoggerFactory())
+        {
+            InnerHandler = new MockResponseDelegatingHandler()
+        };
+
+        // Act
+        var response = handler.Send(new HttpRequestMessage(), CancellationToken.None);
+
+        // Assert
+        receivedSp.Should().BeSameAs(serviceProvider);
+        (await response.Content.ReadAsStringAsync()).Should().Be("DIResponse!");
+    }
+
+    [Fact]
+    public async Task SendAsync_WithFakeResponseFromResponseAsync_ShouldReceiveServiceProvider()
+    {
+        // Arrange
+        var options = new FakeOptions { Enabled = true };
+        IServiceProvider? receivedSp = null;
+        options.AddFakeResponseFromResponseAsync(async (sp, response) =>
+        {
+            receivedSp = sp;
+            return await Task.FromResult<HttpResponseMessage?>(new HttpResponseMessage { Content = new StringContent("DIResponseAsync!"), StatusCode = HttpStatusCode.OK });
+        });
+        var serviceProvider = CreateServiceProvider();
+        var handler = new SutFakeHandler(options, "clienttest", CreateDevelopmentEnvironment(), serviceProvider, CreateLoggerFactory())
+        {
+            InnerHandler = new MockResponseDelegatingHandler()
+        };
+
+        // Act
+        var response = await handler.SendAsync(new HttpRequestMessage(), CancellationToken.None);
+
+        // Assert
+        receivedSp.Should().BeSameAs(serviceProvider);
+        (await response.Content.ReadAsStringAsync()).Should().Be("DIResponseAsync!");
+    }
+
+    private static IServiceProvider CreateServiceProvider() => Substitute.For<IServiceProvider>();
+
+    private static IHostEnvironment CreateDevelopmentEnvironment()
+    {
+        var env = Substitute.For<IHostEnvironment>();
+        env.EnvironmentName.Returns(Environments.Development);
+        return env;
+    }
+
+    private static IHostEnvironment CreateProductionEnvironment()
+    {
+        var env = Substitute.For<IHostEnvironment>();
+        env.EnvironmentName.Returns(Environments.Production);
+        return env;
+    }
+
+    private static ILoggerFactory CreateLoggerFactory()
+    {
+        var logger = Substitute.For<ILogger>();
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        loggerFactory.CreateLogger(Arg.Any<string>()).Returns(logger);
+        return loggerFactory;
+    }
+
+    private static ILoggerFactory CreateDebugLoggerFactory()
+    {
+        var logger = Substitute.For<ILogger>();
+        logger.IsEnabled(LogLevel.Debug).Returns(true);
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        loggerFactory.CreateLogger(Arg.Any<string>()).Returns(logger);
+        return loggerFactory;
     }
 }

--- a/tests/Fresp.Tests/HttpClientBuilderExtensionsTests.cs
+++ b/tests/Fresp.Tests/HttpClientBuilderExtensionsTests.cs
@@ -31,10 +31,10 @@ public class HttpClientBuilderExtensionsTests
             optionsInvoked = true;
             options.ClientName = "TestClient";
             options.Enabled = true;
-            options.AddFakeResponseFromRequest(_ => new HttpResponseMessage());
-            options.AddFakeResponseFromRequestAsync(_ => Task.FromResult<HttpResponseMessage?>(new HttpResponseMessage()));
-            options.AddFakeResponseFromResponse(_ => new HttpResponseMessage());
-            options.AddFakeResponseFromResponseAsync(_ => Task.FromResult<HttpResponseMessage?>(new HttpResponseMessage()));
+            options.AddFakeResponseFromRequest((sp, req) => new HttpResponseMessage());
+            options.AddFakeResponseFromRequestAsync(async (sp, req) => await Task.FromResult<HttpResponseMessage?>(new HttpResponseMessage()));
+            options.AddFakeResponseFromResponse((sp, res) => new HttpResponseMessage());
+            options.AddFakeResponseFromResponseAsync(async (sp, res) => await Task.FromResult<HttpResponseMessage?>(new HttpResponseMessage()));
             options.AddFakeResponseFromRequest<MockFakeResponseFromRequest>();
             options.AddFakeResponseFromRequestAsync<MockFakeResponseFromRequestAsync>();
             options.AddFakeResponseFromResponse<MockFakeResponseFromResponse>();

--- a/tests/Fresp.Tests/Mocks/MockFakeResponseFromRequest.cs
+++ b/tests/Fresp.Tests/Mocks/MockFakeResponseFromRequest.cs
@@ -4,9 +4,9 @@ namespace Fresp.Tests.Mocks;
 
 internal class MockFakeResponseFromRequest : IFakeResponseFromRequest
 {
-    public Func<HttpRequestMessage, HttpResponseMessage?> GetFakeResponseFromRequest()
+    public Func<IServiceProvider, HttpRequestMessage, HttpResponseMessage?> GetFakeResponseFromRequest()
     {
-        return request =>
+        return (sp, request) =>
         {
             if (request.RequestUri != null && request.RequestUri.ToString().EndsWith("/must-fake") && request.Method == HttpMethod.Post)
             {

--- a/tests/Fresp.Tests/Mocks/MockFakeResponseFromRequestAsync.cs
+++ b/tests/Fresp.Tests/Mocks/MockFakeResponseFromRequestAsync.cs
@@ -4,11 +4,11 @@ namespace Fresp.Tests.Mocks;
 
 internal class MockFakeResponseFromRequestAsync : IFakeResponseFromRequestAsync
 {
-    public Func<HttpRequestMessage, Task<HttpResponseMessage?>> GetFakeResponseFromRequestAsync()
+    public Func<IServiceProvider, HttpRequestMessage, Task<HttpResponseMessage?>> GetFakeResponseFromRequestAsync()
     {
-        return async request =>
+        return async (sp, request) =>
         {
-            if (request.RequestUri != null && request.RequestUri.ToString().EndsWith("/must-fake-2") && request.Method == HttpMethod.Get)
+            if (request.RequestUri != null && request.RequestUri.ToString().EndsWith("/must-fake") && request.Method == HttpMethod.Post)
             {
                 return await Task.FromResult<HttpResponseMessage?>(new HttpResponseMessage
                 {
@@ -18,7 +18,7 @@ internal class MockFakeResponseFromRequestAsync : IFakeResponseFromRequestAsync
                 });
             }
 
-            return await Task.FromResult((HttpResponseMessage?)null);
+            return await Task.FromResult<HttpResponseMessage?>(null);
         };
     }
 }

--- a/tests/Fresp.Tests/Mocks/MockFakeResponseFromResponse.cs
+++ b/tests/Fresp.Tests/Mocks/MockFakeResponseFromResponse.cs
@@ -4,9 +4,9 @@ namespace Fresp.Tests.Mocks;
 
 internal class MockFakeResponseFromResponse : IFakeResponseFromResponse
 {
-    public Func<HttpResponseMessage, HttpResponseMessage?> GetFakeResponseFromResponse()
+    public Func<IServiceProvider, HttpResponseMessage, HttpResponseMessage?> GetFakeResponseFromResponse()
     {
-        return response =>
+        return (sp, response) =>
         {
             if (response.StatusCode == HttpStatusCode.ServiceUnavailable)
             {

--- a/tests/Fresp.Tests/Mocks/MockFakeResponseFromResponseAsync.cs
+++ b/tests/Fresp.Tests/Mocks/MockFakeResponseFromResponseAsync.cs
@@ -4,9 +4,9 @@ namespace Fresp.Tests.Mocks;
 
 internal class MockFakeResponseFromResponseAsync : IFakeResponseFromResponseAsync
 {
-    public Func<HttpResponseMessage, Task<HttpResponseMessage?>> GetFakeResponseFromResponseAsync()
+    public Func<IServiceProvider, HttpResponseMessage, Task<HttpResponseMessage?>> GetFakeResponseFromResponseAsync()
     {
-        return async response =>
+        return async (sp, response) =>
         {
             if (response.StatusCode == HttpStatusCode.ServiceUnavailable)
             {
@@ -18,7 +18,7 @@ internal class MockFakeResponseFromResponseAsync : IFakeResponseFromResponseAsyn
                 });
             }
 
-            return await Task.FromResult((HttpResponseMessage?)null);
+            return await Task.FromResult<HttpResponseMessage?>(null);
         };
     }
 }

--- a/tests/Fresp.Tests/SutFakeHandler.cs
+++ b/tests/Fresp.Tests/SutFakeHandler.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Fresp.Tests;
 
-internal class SutFakeHandler(FakeOptions options, string clientName, IHostEnvironment hostEnvironment, ILoggerFactory loggerFactory) : FakeHandler(options, clientName, hostEnvironment, loggerFactory)
+internal class SutFakeHandler(FakeOptions options, string clientName, IHostEnvironment hostEnvironment, IServiceProvider serviceProvider, ILoggerFactory loggerFactory) : FakeHandler(options, clientName, hostEnvironment, serviceProvider, loggerFactory)
 {
     public new HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken) => base.Send(request, cancellationToken);
 


### PR DESCRIPTION
All fake response handler delegates now receive IServiceProvider, enabling dependency injection in both sync and async request/response fakes. Updated FakeOptions API and interfaces to require IServiceProvider in all handler signatures. Refactored internal logic and tests to support DI. Updated README with DI usage examples. Bumped version to 3.0.0 due to breaking changes.